### PR TITLE
[FIX] 카테고리 페이지 Link 오류 수정

### DIFF
--- a/src/pages/search/CategorySearchPage.tsx
+++ b/src/pages/search/CategorySearchPage.tsx
@@ -2,7 +2,7 @@ import { Delete, Goback, Search } from "@/assets/svgs/search";
 import LoadingSpinner from "@/components/common/LoadingSpinner";
 import { useCategoryKeyword } from "@/hooks/search/useSearchApi";
 import React, { useEffect, useState } from "react";
-import { useLocation, useNavigate } from "react-router-dom";
+import { Link, useLocation, useNavigate } from "react-router-dom";
 
 interface CategoryItem {
   auctionId: number;
@@ -226,7 +226,8 @@ const CategorySearchPage: React.FC = () => {
             );
 
             return (
-              <div
+              <Link
+                to={`/item/${item.auctionId}`}
                 key={item.auctionId}
                 className="flex items-center border border-grey04 rounded-[8px] px-3 py-3 mb-3"
               >
@@ -271,7 +272,7 @@ const CategorySearchPage: React.FC = () => {
                       : `현재 최고가: ₩${item.currentPrice.toLocaleString()}`}
                   </span>
                 </div>
-              </div>
+              </Link>
             );
           })}
 

--- a/src/pages/search/SearchResultPage.tsx
+++ b/src/pages/search/SearchResultPage.tsx
@@ -2,7 +2,7 @@ import { Delete, Goback, Search } from "@/assets/svgs/search";
 import LoadingSpinner from "@/components/common/LoadingSpinner";
 import { useSearchAll } from "@/hooks/search/useSearchApi";
 import React, { useEffect, useState } from "react";
-import { useLocation, useNavigate } from "react-router-dom";
+import { Link, useLocation, useNavigate } from "react-router-dom";
 
 interface SearchItem {
   auctionId: number;
@@ -216,7 +216,8 @@ const SearchResultPage: React.FC = () => {
             );
 
             return (
-              <div
+              <Link
+                to={`/item/${item.auctionId}`}
                 key={item.auctionId}
                 className="flex items-center border border-grey09 rounded-[8px] px-3 py-3"
               >
@@ -263,7 +264,7 @@ const SearchResultPage: React.FC = () => {
                       : `현재 최고가: ₩${item.currentPrice.toLocaleString()}`}
                   </span>
                 </div>
-              </div>
+              </Link>
             );
           })}
       </div>


### PR DESCRIPTION
## 🧾 관련 이슈

close : #72 

## 🔍 구현한 내용

카테고리 페이지의 Link를 추가해서 상세페이지로 넘어갈 수 있게 했습니다.

## 📸 스크린샷


## 💡 리뷰어에게
